### PR TITLE
Throwing exceptions with logg.info() arguments.

### DIFF
--- a/bbknn/__init__.py
+++ b/bbknn/__init__.py
@@ -280,7 +280,7 @@ def bbknn(adata, batch_key='batch', approx=True, metric='angular', copy=False, *
 	#call BBKNN proper
 	bbknn_out = bbknn_pca_matrix(pca=pca, batch_list=batch_list,
 								 approx=approx, metric=metric, **kwargs)
-	logg.info('	finished', time=True, end=' ' if settings.verbosity > 2 else '\n')
+	logg.info('	finished', time=True, deep=' ' if settings.verbosity > 2 else '\n')
 	adata.uns['neighbors'] = {}
 	#we'll have a zero distance for our cell of origin, and nonzero for every other neighbour computed
 	adata.uns['neighbors']['params'] = {'n_neighbors': len(bbknn_out[0][0,:].data)+1, 'method': 'umap'}

--- a/bbknn/__init__.py
+++ b/bbknn/__init__.py
@@ -258,7 +258,7 @@ def bbknn(adata, batch_key='batch', approx=True, metric='angular', copy=False, *
 	copy : ``bool``, optional (default: ``False``)
 		If ``True``, return a copy instead of writing to the supplied adata.
 	'''
-	logg.info('computing batch balanced neighbors', r=True)
+	logg.info('computing batch balanced neighbors')
 	adata = adata.copy() if copy else adata
 	#basic sanity checks to begin
 	#is our batch key actually present in the object?

--- a/bbknn/__init__.py
+++ b/bbknn/__init__.py
@@ -280,7 +280,7 @@ def bbknn(adata, batch_key='batch', approx=True, metric='angular', copy=False, *
 	#call BBKNN proper
 	bbknn_out = bbknn_pca_matrix(pca=pca, batch_list=batch_list,
 								 approx=approx, metric=metric, **kwargs)
-	logg.info('	finished', time=True)
+	logg.info('	finished')
 	adata.uns['neighbors'] = {}
 	#we'll have a zero distance for our cell of origin, and nonzero for every other neighbour computed
 	adata.uns['neighbors']['params'] = {'n_neighbors': len(bbknn_out[0][0,:].data)+1, 'method': 'umap'}

--- a/bbknn/__init__.py
+++ b/bbknn/__init__.py
@@ -280,7 +280,7 @@ def bbknn(adata, batch_key='batch', approx=True, metric='angular', copy=False, *
 	#call BBKNN proper
 	bbknn_out = bbknn_pca_matrix(pca=pca, batch_list=batch_list,
 								 approx=approx, metric=metric, **kwargs)
-	logg.info('	finished', time=True, deep=' ' if settings.verbosity > 2 else '\n')
+	logg.info('	finished', time=True)
 	adata.uns['neighbors'] = {}
 	#we'll have a zero distance for our cell of origin, and nonzero for every other neighbour computed
 	adata.uns['neighbors']['params'] = {'n_neighbors': len(bbknn_out[0][0,:].data)+1, 'method': 'umap'}


### PR DESCRIPTION
BBKNN fails to run with the latest version of Scanpy due to its use of passing arguments that are no longer valid.  I just did the simple thing of removing everything other than the message, which has restored its functionality.