### PR TITLE
Enable Faiss with GPU support.

### DIFF
--- a/bbknn/matrix.py
+++ b/bbknn/matrix.py
@@ -9,7 +9,7 @@ import pynndescent
 from scipy.spatial import cKDTree
 from scipy.sparse import coo_matrix
 from umap.umap_ import fuzzy_simplicial_set
-from sklearn.metrics import DistanceMetric
+from sklearn.neighbors import DistanceMetric
 from sklearn.neighbors import KDTree
 try:
 	from scanpy import logging as logg
@@ -96,7 +96,12 @@ def create_tree(data, params):
 									random_state=params['pynndescent_random_state'])
 		ckd.prepare()
 	elif params['computation'] == 'faiss':
-		ckd = faiss.IndexFlatL2(data.shape[1])
+		try: # uses GPU if faiss_gpu available.
+			res = faiss.StandardGpuResources()
+			ckd_ = faiss.IndexFlatL2(data.shape[1])
+			ckd = faiss.index_cpu_to_gpu(res, 0, ckd_)
+		except:
+			ckd = faiss.IndexFlatL2(data.shape[1])
 		ckd.add(data)
 	elif params['computation'] == 'cKDTree':
 		ckd = cKDTree(data)

--- a/bbknn/matrix.py
+++ b/bbknn/matrix.py
@@ -9,7 +9,7 @@ import pynndescent
 from scipy.spatial import cKDTree
 from scipy.sparse import coo_matrix
 from umap.umap_ import fuzzy_simplicial_set
-from sklearn.neighbors import DistanceMetric
+from sklearn.metrics import DistanceMetric
 from sklearn.neighbors import KDTree
 try:
 	from scanpy import logging as logg


### PR DESCRIPTION
PR enables GPU support in Faiss, which gives a speed-up of 4x in my hands-on shape (105322, 50). Sklearn fix is most likely a version issue and can be reverted if this is fine on your side.